### PR TITLE
small bug in beacon.c

### DIFF
--- a/Src/beacon.c
+++ b/Src/beacon.c
@@ -112,7 +112,7 @@ void Beacon_check(void)
 	for(uint8_t i = 0; i < 8; i++)
 	{
 		if(beacon[i].enable == 0)
-			return;
+			continue;
 
 		if((beacon[i].interval > 0) && ((ticks >= beacon[i].next) || (beacon[i].next == 0)))
 		{


### PR DESCRIPTION
Small bug in beacon.c. 
If beacon for example 4 is turned off, beacons 4,5,6,7 do not work.  The fix fixes the problem.
vy73
SQ9KCU